### PR TITLE
Use Content-Disposition filename if available

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -96,7 +96,7 @@ public class SocialSharing extends CordovaPlugin {
                   
                   Matcher matcher = dispositionPattern.matcher(disposition);
                   if(matcher.find()) {
-                    filename = matcher.group(1).replace("'","").replace("\"","").trim();
+                    filename = matcher.group(1).replaceAll("('|\"| )", "");
                     localImage = "file://" + dir + "/" + filename;
                   }
                 }


### PR DESCRIPTION
First of all, thanks for writing this plugin it has proven very useful!

I recently ran into an issue using the plugin when I passed an image url that used a server-side script to generate the image file. For example something like this: /image.php?image_id=1234

When I tried to share this image on Android it failed as the app didn't want to write a file with a name that has query parameters. In the script that generated the image I used the Content-Disposition header to specify a filename for the image and thought it would be a good idea to use the Content-Disposition header for the filename if it was supplied.

I apologise if my code is of poor quality - I'm neither an Android or Java developer. I also understand if you consider that my change makes the code unnecessarily complex / doesn't move in the direction you wanted for the project - I just thought I'd share!
