### PR TITLE
add support to specify activity, if social app offers multiple sharing ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,10 @@ What can we pass to the `shareVia` function?
 You can even test if a sharing option is available with `canShareVia`!
 You'll need to pass everything you want to share, because (at least on Android) some apps may only become available when an image is added.
 The function will invoke the successCallback when it can be shared to via `shareVia`, and the errorCallback if not. As a bonus on Android, the errorCallback contains a JSON Array of available packages you can pass to shareVia.
+You can even specify the activity if the app offers multiple sharing ways, passing 'packageName/activityName'. (for example, WeChat, passing 'com.tencent.mm' or 'com.tencent.mm/com.tencent.mm.ui.tools.ShareImgUI' to share to chat, passing 'com.tencent.mm/com.tencent.mm.ui.tools.ShareToTimeLineUI' to share to moments).
+
 ```html
+<button onclick="window.plugins.socialsharing.canShareVia('com.tencent.mm/com.tencent.mm.ui.tools.ShareToTimeLineUI', 'msg', null, img, null, function(e){alert(e)}, function(e){alert(e)})">is WeChat available on Android?</button>
 <button onclick="window.plugins.socialsharing.canShareVia('com.apple.social.facebook', 'msg', null, null, null, function(e){alert(e)}, function(e){alert(e)})">is facebook available on iOS?</button>
 <button onclick="window.plugins.socialsharing.canShareVia('whatsapp', 'msg', null, null, null, function(e){alert(e)}, function(e){alert(e)})">is WhatsApp available?</button>
 <button onclick="window.plugins.socialsharing.canShareVia('sms', 'msg', null, null, null, function(e){alert(e)}, function(e){alert(e)})">is SMS available?</button>

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.text.Html;
 import android.util.Base64;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
@@ -197,13 +198,21 @@ public class SocialSharing extends CordovaPlugin {
         }
 
         if (appPackageName != null) {
-          final ActivityInfo activity = getActivity(sendIntent, appPackageName);
+        	String packageName = appPackageName;
+        	String givenActivityName = null;
+        	if(packageName.indexOf("/") > 0) {
+        		String[] items = appPackageName.split("/");
+        		packageName = items[0];
+        		givenActivityName = items[1];
+        	}
+          final ActivityInfo activity = getActivity(sendIntent, packageName);
           if (activity != null) {
             if (peek) {
               callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
             } else {
               sendIntent.addCategory(Intent.CATEGORY_LAUNCHER);
-              sendIntent.setComponent(new ComponentName(activity.applicationInfo.packageName, activity.name));
+              sendIntent.setComponent(new ComponentName(activity.applicationInfo.packageName, 
+            		  (givenActivityName!=null) ? givenActivityName : activity.name));
               mycordova.startActivityForResult(plugin, sendIntent, 0);
             }
           }


### PR DESCRIPTION
You can specify the activity if the app offers multiple sharing ways, just passing 'packageName/activityName' to shareVia. 

For example, WeChat, passing 'com.tencent.mm' or 'com.tencent.mm/com.tencent.mm.ui.tools.ShareImgUI' to share to chat, passing 'com.tencent.mm/com.tencent.mm.ui.tools.ShareToTimeLineUI' to share to moments.
