### PR TITLE
fix: android email html check supports multiline html now

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -110,7 +110,8 @@ public class SocialSharing extends CordovaPlugin {
       public void run() {
         final Intent draft = new Intent(Intent.ACTION_SEND_MULTIPLE);
         if (notEmpty(message)) {
-          if (message.matches(".*<[^>]+>.*")) {
+          Pattern htmlPattern = Pattern.compile(".*\\<[^>]+>.*", Pattern.DOTALL);
+          if (htmlPattern.matcher(message).matches()) {
             draft.putExtra(android.content.Intent.EXTRA_TEXT, Html.fromHtml(message));
             draft.setType("text/html");
           } else {


### PR DESCRIPTION
HTML-Mails on Android were not handled as html if the message was multiline, as the regex has never matched.
