### PR TITLE
Possible bug in isAvailableForServiceType

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -172,6 +172,14 @@
 
 - (bool)isAvailableForSharing:(CDVInvokedUrlCommand*)command
                          type:(NSString *) type {
+  // isAvailableForServiceType returns true if you pass it a type that is not
+  // in the defined constants, this is probably a bug on apples part
+  if(!([type isEqualToString:SLServiceTypeFacebook]
+       || [type isEqualToString:SLServiceTypeTwitter]
+       || [type isEqualToString:SLServiceTypeTencentWeibo]
+       || [type isEqualToString:SLServiceTypeSinaWeibo])) {
+    return false;
+  }
   // wrapped in try-catch, because isAvailableForServiceType may crash if an invalid type is passed
   @try {
     return [SLComposeViewController isAvailableForServiceType:type];


### PR DESCRIPTION
We ran into a problem where a user did not have whatsapp installed and this plugin did not recognize it properly. 
After investigation, we traced it down to a problem in [`SLComposeViewController isAvailableForServiceType`](https://developer.apple.com/library/prerelease/ios/documentation/NetworkingInternet/Reference/SLComposeViewController_Class/index.html#//apple_ref/occ/clm/SLComposeViewController/isAvailableForServiceType:). Passing the string "whatsapp" oddly returned true for this method; actually any string not in the [defined constants](https://developer.apple.com/library/prerelease/ios/documentation/Social/Reference/SLRequest_Class/index.html#//apple_ref/doc/constant_group/Service_Type_Constants) returned true in our tests.

The proposed fix first checks if the type is in the defined constants and return false if not.
