### PR TITLE
iOS WkWebView workaround: add a setIPadPopupCoordinates method

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,18 @@ Note that since iOS 8 this popup is the only way Apple allows you to share stuff
 the popup at the bottom of the screen (seems like a logical default because that's where it previously was as well).
 You can however override this position in the same way as explained above.
 
+**Note**: when using the [WkWebView polyfill](https://github.com/Telerik-Verified-Plugins/WKWebView) the `iPadPopupCoordinates` overrides [doesn't work](https://github.com/Telerik-Verified-Plugins/WKWebView/issues/77) so you can call the alternative `setIPadPopupCoordinates` method to define the popup position just before you call the `share` method.
+
+example :
+
+```js
+var targetRect = event.targetElement.getBoundingClientRect(),
+    targetBounds = targetRect.left + ',' + targetRect.top + ',' + targetRect.width + ',' + targetRect.height;
+
+window.plugins.socialsharing.setIPadPopupCoordinates(targetBounds);
+window.plugins.socialsharing.share('Hello from iOS :)')
+```
+
 ## 5. Credits ##
 
 This plugin was enhanced for Plugman / PhoneGap Build by [Eddy Verbruggen](http://www.x-services.nl).

--- a/src/ios/SocialSharing.h
+++ b/src/ios/SocialSharing.h
@@ -9,6 +9,7 @@
 @property (retain) CDVInvokedUrlCommand * command;
 
 - (void)available:(CDVInvokedUrlCommand*)command;
+- (void)setIPadPopupCoordinates:(CDVInvokedUrlCommand*)command;
 - (void)share:(CDVInvokedUrlCommand*)command;
 - (void)canShareVia:(CDVInvokedUrlCommand*)command;
 - (void)canShareViaEmail:(CDVInvokedUrlCommand*)command;

--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -8,6 +8,7 @@
 
 @implementation SocialSharing {
   UIPopoverController *_popover;
+  NSString *_popupCoordinates;
 }
 
 - (void)pluginInitialize {
@@ -26,7 +27,14 @@
 }
 
 - (NSString*)getIPadPopupCoordinates {
+  if (_popupCoordinates != nil) {
+    return _popupCoordinates;
+  }
   return [self.webView stringByEvaluatingJavaScriptFromString:@"window.plugins.socialsharing.iPadPopupCoordinates();"];
+}
+
+- (void)setIPadPopupCoordinates:(CDVInvokedUrlCommand*)command {
+  _popupCoordinates  = [command.arguments objectAtIndex:0];
 }
 
 - (CGRect)getPopupRectFromIPadPopupCoordinates:(NSArray*)comps {

--- a/www/SocialSharing.js
+++ b/www/SocialSharing.js
@@ -14,6 +14,11 @@ SocialSharing.prototype.iPadPopupCoordinates = function () {
   return "-1,-1,-1,-1";
 };
 
+SocialSharing.prototype.setIPadPopupCoordinates = function (coords) {
+  // left,top,width,height
+  cordova.exec(function() {}, this._getErrorCallback(function() {}, "setIPadPopupCoordinates"), "SocialSharing", "setIPadPopupCoordinates", [coords]);
+};
+
 SocialSharing.prototype.available = function (callback) {
   cordova.exec(function (avail) {
     callback(avail ? true : false);


### PR DESCRIPTION
Hey,

Here's a workaround for the WkWebView incompatibilty describe here https://github.com/Telerik-Verified-Plugins/WKWebView/issues/77

Simply added a `setIPadPopupCoordinates` that we can call before any `share`
