### PR TITLE
change dataFromBase64String to cdv_dataFromBase64String (deprecated sinc...

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -291,7 +291,7 @@
           fileName = @"attachment.";
           fileName = [fileName stringByAppendingString:(NSString*)[[mimeType componentsSeparatedByString: @"/"] lastObject]];
           NSString *base64content = (NSString*)[[basename componentsSeparatedByString: @","] lastObject];
-          data = [NSData dataFromBase64String:base64content];
+          data = [NSData cdv_dataFromBase64String:base64content];
         } else {
           fileName = [basename pathComponents].lastObject;
           mimeType = [self getMimeTypeFromFileExtension:[basename pathExtension]];
@@ -522,7 +522,7 @@
       NSString *fileType = (NSString*)[[[fileName substringFromIndex:5] componentsSeparatedByString: @";"] objectAtIndex:0];
       fileType = (NSString*)[[fileType componentsSeparatedByString: @"/"] lastObject];
       NSString *base64content = (NSString*)[[fileName componentsSeparatedByString: @","] lastObject];
-      NSData *fileData = [NSData dataFromBase64String:base64content];
+      NSData *fileData = [NSData cdv_dataFromBase64String:base64content];
       file = [NSURL fileURLWithPath:[self storeInFile:[NSString stringWithFormat:@"%@.%@", @"file", fileType] fileData:fileData]];
     } else {
       // assume anywhere else, on the local filesystem


### PR DESCRIPTION
Hi Eddy,

first off, thanks for your awesome plugin!
This is tiny, but I just noticed that Xcode displays a deprecated warning for dataFromBase64String. Since cordova 3.8.0 this should be cdv_dataFromBase64String. I don't know how you want to handle this, since this change would not be compatible with cordova < 3.8 afaik. 
Just thought pass this on, just decline this PR if you want to keep support for cordova < 3.8.
Thanks.
 