### PR TITLE
Fixed issue #432

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -18,7 +18,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.PluginResult;
-import org.json.JSONArray;
+import org.json.JSONArray
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -233,7 +233,7 @@ public class SocialSharing extends CordovaPlugin {
         if (notEmpty(message)) {
           sendIntent.putExtra(android.content.Intent.EXTRA_TEXT, message);
           // sometimes required when the user picks share via sms
-          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+          if (Build.VERSION.SDK_INT < 22) { // LOLLIPOP
             sendIntent.putExtra("sms_body", message);
           }
         }

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -233,7 +233,7 @@ public class SocialSharing extends CordovaPlugin {
         if (notEmpty(message)) {
           sendIntent.putExtra(android.content.Intent.EXTRA_TEXT, message);
           // sometimes required when the user picks share via sms
-          if (Build.VERSION.SDK_INT < 22) { // LOLLIPOP
+          if (Build.VERSION.SDK_INT < 21) { // LOLLIPOP
             sendIntent.putExtra("sms_body", message);
           }
         }

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -232,7 +232,10 @@ public class SocialSharing extends CordovaPlugin {
         }
         if (notEmpty(message)) {
           sendIntent.putExtra(android.content.Intent.EXTRA_TEXT, message);
-          sendIntent.putExtra("sms_body", message); // sometimes required when the user picks share via sms
+          // sometimes required when the user picks share via sms
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            sendIntent.putExtra("sms_body", message);
+          }
         }
 
         if (appPackageName != null) {


### PR DESCRIPTION
More details: #432 

I think it's a pretty safe bet to replace `if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)` with `if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT)` but I didn't as don't have any Android 4 device to test with.