### PR TITLE
Link argument not specified in javascript call

### DIFF
--- a/src/wp8/SocialSharing.cs
+++ b/src/wp8/SocialSharing.cs
@@ -26,7 +26,7 @@ namespace Cordova.Extension.Commands
             var files = JsonHelper.Deserialize<string[]>(options[2]);
             var link = options[3];
 
-            if (!"null".Equals(link))
+            if (link != null && !"null".Equals(link))
             {
                 ShareLinkTask shareLinkTask = new ShareLinkTask();
                 shareLinkTask.Title = title;


### PR DESCRIPTION
If the plugin's javascript "share" method is called without specifying the 3rd and 4th arguments, such as in: 
`window.plugins.socialsharing.share('Message and subject', 'The subject')`
The condition:
`!"null".Equals(link)`
in the C# implementation is satisfied (link is null and not "null") and the method call is incorrectly interpreted as a "share link" intent, thus resulting in an exception being thrown when the following instruction is executed:
`shareLinkTask.LinkUri = new System.Uri(link, System.UriKind.Absolute)`