### PR TITLE
refresh globalmailcomposer

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -295,6 +295,8 @@
       return;
     }
 
+    [self cycleTheGlobalMailComposer];
+
     self.globalMailComposer.mailComposeDelegate = self;
 
     if ([command.arguments objectAtIndex:0] != (id)[NSNull null]) {


### PR DESCRIPTION
See https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin/issues/559

If I add an email while the app is running and then try to send an email with shareViaEmail, the app crashes unless I call cycleTheGlobalMailComposer