### PR TITLE
Remove unneeded source-file element from Windows platform

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -81,7 +81,6 @@
     <js-module src="src/windows/SocialSharingProxy.js" name="SocialSharingProxy">
       <merges target="" />
     </js-module>
-    <source-file src="" />
   </platform>
 
 </plugin>


### PR DESCRIPTION
When I install the plugin today, a copy of the plugin folder shows up in Visual Studio like this:
![image](https://cloud.githubusercontent.com/assets/2394156/17195866/5b5190e4-5415-11e6-8e8f-38849f99bf4f.png)

Visual Studio displays the folder as a file, and seems to include the folder's contents into the App package. I think this is unnecessary.