### PR TITLE
Don't set data when attaching file

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -437,7 +437,7 @@ public class SocialSharing extends CordovaPlugin {
       //get file MIME type
       String type = getMIMEType(image);
       //set intent data and Type
-      sendIntent.setDataAndType(Uri.fromFile(new File(image)), type);
+      sendIntent.setType(type);
     }
     return Uri.parse(localImage);
   }


### PR DESCRIPTION
As discussed in #618, this swaps `sendIntent.setDataAndType` for `sendIntent.setType`, which seems like the right thing to do. [The docs for ACTION_SEND](https://developer.android.com/reference/android/content/Intent.html#ACTION_SEND) say the data should be sent as `EXTRA_STREAM` and the type is the MIME type of the data sent, which is what we're doing. It doesn't mention `setData` at all. `ACTION_SENDTO` just below it says that the data field is the target (i.e. the To: address), and I suspect that internally, `ACTION_SEND` and `ACTION_SENDTO` are closely related. That's apparently causing the file URI to appear in the To: address.