### PR TITLE
Disabled animation when sharing via SMS

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -479,7 +479,7 @@ static NSString *const kShareOptionUrl = @"url";
     _command = command;
     [self.commandDelegate runInBackground:^{
       picker.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
-      [[self getTopMostViewController] presentViewController:picker animated:YES completion:nil];
+      [[self getTopMostViewController] presentViewController:picker animated:NO completion:nil];
     }];
   } else {
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"not available"];


### PR DESCRIPTION
Addresses issue: `iOS Keyboard doesn't appear onSMS activation with multiple numbers`
https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin/issues/405