### PR TITLE
Fix android.os.FileUriExposedException #714

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,14 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     </config-file>
 
+    <config-file target="AndroidManifest.xml" parent="/manifest/application">
+      <provider android:authorities="com.socialsharing.provider" android:exported="false" android:grantUriPermissions="true" android:name="android.support.v4.content.FileProvider">
+        <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/sharing_paths" />
+      </provider>
+    </config-file>
+
     <source-file src="src/android/nl/xservices/plugins/SocialSharing.java" target-dir="src/nl/xservices/plugins"/>
+    <source-file src="src/android/res/xml/sharing_paths.xml" target-dir="res/xml"/>
   </platform>
 
   <!-- wp8 -->

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -34,6 +34,8 @@ import java.util.TimerTask;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import android.support.v4.content.FileProvider;
+
 public class SocialSharing extends CordovaPlugin {
 
   private static final String ACTION_AVAILABLE_EVENT = "available";
@@ -244,6 +246,7 @@ public class SocialSharing extends CordovaPlugin {
               Uri fileUri = null;
               for (int i = 0; i < files.length(); i++) {
                 fileUri = getFileUriAndSetType(sendIntent, dir, files.getString(i), subject, i);
+                fileUri = FileProvider.getUriForFile(webView.getContext(), "com.socialsharing.provider", new File(fileUri.getPath()));
                 if (fileUri != null) {
                   fileUris.add(fileUri);
                 }

--- a/src/android/res/xml/sharing_paths.xml
+++ b/src/android/res/xml/sharing_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path name="socialsharing_downloads" path="socialsharing-downloads/" />
+</paths>


### PR DESCRIPTION
Needs more testing probably but adding FileProvider seems to satisfy android SDK 24+ for sharing files.

There's probably a better way to create a new File from getFileUriAndSetType