### PR TITLE
Fix for potential conflicts with other plugins using FileProvider

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -62,7 +62,7 @@
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <provider android:authorities="com.socialsharing.provider" android:exported="false" android:grantUriPermissions="true" android:name="android.support.v4.content.FileProvider">
+      <provider android:authorities="com.socialsharing.provider" android:exported="false" android:grantUriPermissions="true" android:name="nl.xservices.plugins.FileProvider">
         <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/sharing_paths" />
       </provider>
     </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,6 +68,7 @@
     </config-file>
 
     <source-file src="src/android/nl/xservices/plugins/SocialSharing.java" target-dir="src/nl/xservices/plugins"/>
+    <source-file src="src/android/nl/xservices/plugins/FileProvider.java" target-dir="src/nl/xservices/plugins"/>
     <source-file src="src/android/res/xml/sharing_paths.xml" target-dir="res/xml"/>
   </platform>
 

--- a/src/android/nl/xservices/plugins/FileProvider.java
+++ b/src/android/nl/xservices/plugins/FileProvider.java
@@ -1,0 +1,5 @@
+package nl.xservices.plugins;
+
+
+public class FileProvider extends android.support.v4.content.FileProvider {
+}


### PR DESCRIPTION
This PR is a workaround for https://issues.apache.org/jira/browse/CB-8401 which is caused by a possible bug in the maifest-merger within androids build process as described here https://code.google.com/p/android/issues/detail?id=231824&thanks=231824&ts=1483974507
also discussed on StackOverflow http://stackoverflow.com/questions/40746144/error-with-duplicated-fileprovider-in-manifest-xml-with-cordova