### PR TITLE
Fix Facebook save instead of share activity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-x-socialsharing"
-        version="5.1.5">
+        version="5.1.6">
 
   <name>SocialSharing</name>
 

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -83,10 +83,10 @@ public class SocialSharing extends CordovaPlugin {
     } else if (ACTION_SHARE_VIA_TWITTER_EVENT.equals(action)) {
       return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "twitter", null, false, true);
     } else if (ACTION_SHARE_VIA_FACEBOOK_EVENT.equals(action)) {
-      return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "com.facebook.katana", null, false, true);
+      return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "com.facebook.katana", null, false, true, "com.facebook.composer.shareintent");
     } else if (ACTION_SHARE_VIA_FACEBOOK_WITH_PASTEMESSAGEHINT.equals(action)) {
       this.pasteMessage = args.getString(4);
-      return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "com.facebook.katana", null, false, true);
+      return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "com.facebook.katana", null, false, true, "com.facebook.composer.shareintent");
     } else if (ACTION_SHARE_VIA_WHATSAPP_EVENT.equals(action)) {
       if (notEmpty(args.getString(4))) {
         return shareViaWhatsAppDirectly(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), args.getString(4));
@@ -218,6 +218,19 @@ public class SocialSharing extends CordovaPlugin {
   }
 
   private boolean doSendIntent(
+          final CallbackContext callbackContext,
+          final String msg,
+          final String subject,
+          final JSONArray files,
+          final String url,
+          final String appPackageName,
+          final String chooserTitle,
+          final boolean peek,
+          final boolean boolResult) {
+    return doSendIntent(callbackContext, msg, subject, files, url, appPackageName, chooserTitle, peek, boolResult, null);
+  }
+
+  private boolean doSendIntent(
       final CallbackContext callbackContext,
       final String msg,
       final String subject,
@@ -226,7 +239,8 @@ public class SocialSharing extends CordovaPlugin {
       final String appPackageName,
       final String chooserTitle,
       final boolean peek,
-      final boolean boolResult) {
+      final boolean boolResult,
+      final String appName) {
 
     final CordovaInterface mycordova = cordova;
     final CordovaPlugin plugin = this;
@@ -299,7 +313,7 @@ public class SocialSharing extends CordovaPlugin {
             packageName = items[0];
             passedActivityName = items[1];
           }
-          final ActivityInfo activity = getActivity(callbackContext, sendIntent, packageName);
+          final ActivityInfo activity = getActivity(callbackContext, sendIntent, packageName, appName);
           if (activity != null) {
             if (peek) {
               callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
@@ -653,7 +667,7 @@ public class SocialSharing extends CordovaPlugin {
     return null;
   }
 
-  private ActivityInfo getActivity(final CallbackContext callbackContext, final Intent shareIntent, final String appPackageName) {
+  private ActivityInfo getActivity(final CallbackContext callbackContext, final Intent shareIntent, final String appPackageName, final String appName) {
     final PackageManager pm = webView.getContext().getPackageManager();
     List<ResolveInfo> activityList = pm.queryIntentActivities(shareIntent, 0);
     for (final ResolveInfo app : activityList) {

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -672,7 +672,9 @@ public class SocialSharing extends CordovaPlugin {
     List<ResolveInfo> activityList = pm.queryIntentActivities(shareIntent, 0);
     for (final ResolveInfo app : activityList) {
       if ((app.activityInfo.packageName).contains(appPackageName)) {
-        return app.activityInfo;
+        if (appName == null || (app.activityInfo.name).contains(appName)) {
+          return app.activityInfo;
+        }
       }
     }
     // no matching app found


### PR DESCRIPTION
This fixes #732 
queryIntentActivities find more than one activity for the package "com.facebook.katana" and when the first activity that it finds is the save activity we have the bug.
So i added an additional filter on Activity name in getActivity function, in this case the activity name is "com.facebook.composer.shareintent" and you can specify it when calling doSendIntent.

I also incremented the patch number, in plugin.xml.