### PR TITLE
quick fix to support mp3 files

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -387,6 +387,8 @@ public class SocialSharing extends CordovaPlugin {
     String localImage = image;
     if (image.endsWith("mp4") || image.endsWith("mov") || image.endsWith("3gp")){
       sendIntent.setType("video/*");
+    } else if (image.endsWith("mp3")) {
+      sendIntent.setType("audio/x-mpeg");  
     } else {
       sendIntent.setType("image/*");
     }


### PR DESCRIPTION
I did a quick (and dirty?) fix to support mp3 files. If it's not useful or ugly please reject the PR.

With the actual version of the plugin sharing audio files from the cordova www/ folder wasn't working for me. After that fix I can share mp3 files.

**Notice:** Don't set a subject, text or url in the options object if you want to share mp3 files. Only set the file(s) to be shared. Otherwise there will be an error in WhatsApp.