### PR TITLE
fix ios app crash when canceling a share without select an app

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -137,7 +137,7 @@ static NSString *const kShareOptionUrl = @"url";
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         [activityVC setCompletionHandler:^(NSString *activityType, BOOL completed) {
           [self cleanupStoredFiles];
-          NSDictionary * result = @{@"completed":@(completed), @"app":activityType};
+          NSDictionary * result = @{@"completed":@(completed), @"app":activityType == nil ? @"" : activityType};
           CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
           [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }];


### PR DESCRIPTION
iOS app was crashing when trying to cancel a share without select an app because activityType was nil in that case. Fixed it by adding a validation.