### PR TITLE
Implement Web Share API

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,23 @@ Here's the list of available activities you can disable :
  - com.apple.UIKit.activity.AddToReadingList
  - com.apple.UIKit.activity.AirDrop
 
+#### Web Share API
+
+Chrome is introducing a new [Web Share API](https://github.com/WICG/web-share) to share data.
+
+```js
+navigator.share({
+  'title': 'Optional title',
+  'text': 'Optional message',
+  'url': 'http://www.myurl.com'
+}).then(function() {
+  console.log('Successful share');
+}).catch(function(error) {
+  console.log('Error sharing:', error)
+});
+```
+
+It doesn't provide all the options that the other share methods do but it is spec compliant.
 
 ## 4b. Usage on Windows Phone
 The available methods on WP8 are: `available`, `canShareViaEmail`, `share`, `shareViaEmail` and `shareViaSMS`.
@@ -496,7 +513,7 @@ This is a stright forward approach - you just manually edit the .plist file - ei
 There is a plugin designed specifically to address query schema whitelisting. You can find the plugin and how to use it [here](https://www.npmjs.com/package/cordova-plugin-queries-schemes). In general, after installation, you can change plugin.xml file under the plugin subfolder within the plugins directory of your project to add the required schemas. Here again though, you have to edit an additional file and should take care not to overwrite it when making changes to your project.
 
 ### Use Custom Config plugin
-The Custom Config plugin ([here](https://github.com/dpa99c/cordova-custom-config)) allows you to add configuration to your platforms "native" configuration files (e.g. .plist or AndroidManifest.xml) through the project's main config.xml file. 
+The Custom Config plugin ([here](https://github.com/dpa99c/cordova-custom-config)) allows you to add configuration to your platforms "native" configuration files (e.g. .plist or AndroidManifest.xml) through the project's main config.xml file.
 
 To address query schema issue, after installaing the plugin you can edit the iOS platform section of your config.xml (in the project main folder) to include the required entries:
 
@@ -506,11 +523,11 @@ To address query schema issue, after installaing the plugin you can edit the iOS
         version="0.9.1"
         xmlns="http://www.w3.org/ns/widgets"
         xmlns:cdv="http://cordova.apache.org/ns/1.0">
-        
+
     <!-- a bunch of elements like name, description etc -->
-    
+
     <platform name="ios">
-        
+
         <!-- add this entry -->
         <config-file platform="ios" target="*-Info.plist" parent="LSApplicationQueriesSchemes">
             <array>

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,6 +25,8 @@
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
 
+  <dependency id="es6-promise-plugin"/>
+
   <js-module src="www/SocialSharing.js" name="SocialSharing">
     <clobbers target="window.plugins.socialsharing" />
   </js-module>

--- a/tests/test.js
+++ b/tests/test.js
@@ -162,6 +162,141 @@ exports.defineAutoTests = function () {
         });
       });
     });
+
+    describe('navigator.share', function() {
+      it('navigator should have a `share` method that returns a promise', function() {
+        expect(navigator.share).toBeDefined();
+        expect(typeof navigator.share).toBe('function');
+      });
+    });
+
+    describe('share should return a promise ', function(){
+    	it ('share should return a promise', function(){
+    		var dict = {
+    		  title: 'sample title',
+          text: 'sample text',
+  			  url: 'sample url'
+  			};
+
+        try {
+          var promise = navigator.share(dict);
+        	expect(promise).toBeDefined();
+          expect(typeof promise.then).toBe('function');
+          promise.then(function() {
+            done();
+          }, function(err) {
+            expect(err).toBeDefined();
+            fail(err);
+            done();
+          });
+        } catch (err) {
+          fail(err);
+          done();
+        }
+      });
+
+      it ('share should resolve with only text', function(){
+      	var dict = {
+      	  text: 'sample text'
+    		};
+
+        try {
+          var promise = navigator.share(dict);
+      		expect(promise).toBeDefined();
+          expect(typeof promise.then).toBe('function');
+          promise.then(function() {
+            done();
+          }, function(err) {
+            expect(err).toBeDefined();
+            fail(err);
+            done();
+          });
+        } catch (err) {
+          fail(err);
+          done();
+        }
+      });
+
+      it ('share should resolve with only a url', function(){
+      	var dict = {
+          url: 'sample title'
+        };
+
+        try {
+          var promise = navigator.share(dict);
+      		expect(promise).toBeDefined();
+          expect(typeof promise.then).toBe('function');
+          promise.then(function() {
+            done();
+          }, function(err) {
+            expect(err).toBeDefined();
+            fail(err);
+            done();
+          });
+        } catch (err) {
+          fail(err);
+          done();
+        }
+      });
+
+      it ('share should resolve with only a title', function(){
+      	var dict = {
+      	  title: 'sample title'
+    		};
+
+        try {
+          var promise = navigator.share(dict);
+      		expect(promise).toBeDefined();
+          expect(typeof promise.then).toBe('function');
+          promise.then(function() {
+            done();
+          }, function(err) {
+            expect(err).toBeDefined();
+            fail(err);
+            done();
+          });
+        } catch (err) {
+          fail(err);
+          done();
+        }
+      });
+
+      it ('share should reject an empty options', function(){
+        try {
+          var promise = navigator.share({});
+      		expect(promise).toBeDefined();
+          expect(typeof promise.then).toBe('function');
+          promise.then(function() {
+            fail('something in options should be set');
+            done();
+          }, function(err) {
+            expect(err).toBeDefined();
+            done();
+          });
+        } catch (err) {
+          fail(err);
+          done();
+        }
+      });
+
+      it ('share should reject an undefined options', function(){
+        try {
+          var promise = navigator.share();
+      		expect(promise).toBeDefined();
+          expect(typeof promise.then).toBe('function');
+          promise.then(function() {
+            fail('options should not be undefined');
+            done();
+          }, function(err) {
+            expect(err).toBeDefined();
+            done();
+          });
+        } catch (err) {
+          fail(err);
+          done();
+        }
+      });
+    });
   });
 };
 

--- a/www/SocialSharing.js
+++ b/www/SocialSharing.js
@@ -28,6 +28,23 @@ SocialSharing.prototype.shareWithOptions = function (options, successCallback, e
   cordova.exec(successCallback, this._getErrorCallback(errorCallback, "shareWithOptions"), "SocialSharing", "shareWithOptions", [options]);
 };
 
+SocialSharing.prototype.shareW3C = function (sharedata) {
+  return new Promise(function(resolve, reject) {
+    var options = {
+      subject: sharedata.title,
+      message: sharedata.text,
+      url: sharedata.url
+    };
+    if(sharedata.hasOwnProperty('title') ||
+        sharedata.hasOwnProperty('text') ||
+        sharedata.hasOwnProperty('url')) {
+          cordova.exec(resolve, reject, "SocialSharing", "shareWithOptions", [options]);
+    } else {
+      reject();
+    }
+  });
+};
+
 SocialSharing.prototype.share = function (message, subject, fileOrFileArray, url, successCallback, errorCallback) {
   cordova.exec(successCallback, this._getErrorCallback(errorCallback, "share"), "SocialSharing", "share", [message, subject, this._asArray(fileOrFileArray), url]);
 };
@@ -116,6 +133,7 @@ SocialSharing.install = function () {
   }
 
   window.plugins.socialsharing = new SocialSharing();
+  navigator.share = window.plugins.socialsharing.shareW3C;
   return window.plugins.socialsharing;
 };
 


### PR DESCRIPTION
Hi Eddy,

Chrome will be introducing the [Web Share API](https://github.com/WICG/web-share) so I thought it would be nice if your plugin would also implement this API. Basically it adds a new method called `shareW3C` which is attached at `navigator.share`.