### PR TITLE
add dependency versions for es6-promise-plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
 
-  <dependency id="es6-promise-plugin"/>
+  <dependency id="es6-promise-plugin" version="4.1.0" />
 
   <js-module src="www/SocialSharing.js" name="SocialSharing">
     <clobbers target="window.plugins.socialsharing" />


### PR DESCRIPTION
this resolves an issue when attempting to install the plugin using cordova 7, node 8.1.3, npm 5.0.3 where npm messes up the package.json and ends up symlinking the es6-promise-pluigin directory to itself causing npm to hard crash.

I fixed this a similar issue for another plugin a few weeks ago.