### PR TITLE
fix Save Image on iOS 11 - NSPhotoLibraryAddUsageDescription in config.xml -> Info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,6 +40,10 @@
         <param name="onload" value="true" />
       </feature>
     </config-file>
+          
+    <config-file target="*-Info.plist" parent="NSPhotoLibraryAddUsageDescription">
+      <string>This app requires photo library access to function properly.</string>
+    </config-file>
 
     <header-file src="src/ios/NSString+SSURLEncoding.h"/>
     <source-file src="src/ios/NSString+SSURLEncoding.m"/>


### PR DESCRIPTION
NSPhotoLibraryAddUsageDescription ("Privacy - Photo Library Additions Usage Description") in Info.plist (new in iOS 11)