### PR TITLE
Use `keyWindow` instead of `delegate`

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -387,7 +387,7 @@ static NSString *const kShareOptionUrl = @"url";
           else
           {
               mimeType = (NSString*)[[[basename substringFromIndex:rangeData.location+rangeData.length] componentsSeparatedByString: @";"] objectAtIndex:0];
-              
+
               //Find df anywhere in string
               NSRange rangeDF = [basename rangeOfString:@"df:"];
               //If not found fallback to default name
@@ -398,8 +398,8 @@ static NSString *const kShareOptionUrl = @"url";
                   //Found, apply name
                   fileName = (NSString*)[[[basename substringFromIndex:rangeDF.location+rangeDF.length] componentsSeparatedByString: @";"] objectAtIndex:0];
               }
-              
-              
+
+
               NSString *base64content = (NSString*)[[basename componentsSeparatedByString: @","] lastObject];
               data = [SocialSharing dataFromBase64String:base64content];
           }
@@ -421,7 +421,7 @@ static NSString *const kShareOptionUrl = @"url";
 }
 
 - (UIViewController*) getTopMostViewController {
-  UIViewController *presentingViewController = [[[UIApplication sharedApplication] delegate] window].rootViewController;
+  UIViewController *presentingViewController = [[UIApplication sharedApplication] keyWindow].rootViewController;
   while (presentingViewController.presentedViewController != nil) {
     presentingViewController = presentingViewController.presentedViewController;
   }
@@ -738,7 +738,7 @@ static NSString *const kShareOptionUrl = @"url";
      } else if (rangeData.location != NSNotFound ){
         //If found "data:"
         NSString *fileType  = (NSString*)[[[fileName substringFromIndex:rangeData.location+rangeData.length] componentsSeparatedByString: @";"] objectAtIndex:0];
-        
+
         NSString* attachmentName;
         //Find df anywhere in string
         NSRange rangeDF = [fileName rangeOfString:@"df:"];
@@ -750,8 +750,8 @@ static NSString *const kShareOptionUrl = @"url";
             //Found, apply name
             attachmentName = (NSString*)[[[fileName substringFromIndex:rangeDF.location+rangeDF.length] componentsSeparatedByString: @";"] objectAtIndex:0];
         }
-        
-        
+
+
         NSString *base64content = (NSString*)[[fileName componentsSeparatedByString: @","] lastObject];
         NSData* data = [SocialSharing dataFromBase64String:base64content];
         file = [NSURL fileURLWithPath:[self storeInFile:attachmentName fileData:data]];


### PR DESCRIPTION
This problem is not new and was already solved here #396. I am using
exaclty the same setup and unfortunatelly the sharing controller is
hidden underneath the inappbrowser controller and the `getTopMostViewController`
method fails to identify the correct `presentingViewController`.

By changing the `UIViewController` to be obtained from the `delegate` to
the `keyWindow` everything seems to be working as expected.