### PR TITLE
Using the socialSharing's shareViaEmail method crash with Android 8.0.

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -160,7 +160,8 @@ public class SocialSharing extends CordovaPlugin {
             if (dir != null) {
               ArrayList<Uri> fileUris = new ArrayList<Uri>();
               for (int i = 0; i < files.length(); i++) {
-                final Uri fileUri = getFileUriAndSetType(draft, dir, files.getString(i), subject, i);
+                Uri fileUri = getFileUriAndSetType(draft, dir, files.getString(i), subject, i);
+                fileUri = FileProvider.getUriForFile(webView.getContext(), cordova.getActivity().getPackageName()+".sharing.provider", new File(fileUri.getPath()));
                 if (fileUri != null) {
                   fileUris.add(fileUri);
                 }


### PR DESCRIPTION
Hi

	I would like to propose this correction for a crash when using the SocialMedia's shareViaEmail method with Android 8.0 and probably up. 

	Thanks

Commit comment:

DESCRIPTION:
Using the socialSharing's shareViaEmail method crash with Android 8.0 and probably up.

Crash message is "**android.os.FileUriExposedException:** " [...filename of file to share via Email....] " **exposed beyond app through clipdata.item.geturi()**".
It seems to be in relation that these OS are now more restrictive about passing file URI ("file://") with Intent.
However, the doSendIntent method, used by shareWithOptions have no issue. The latter get it's fileURI from FileProvider.

So this correction duplicate the way "doSendIntent" method get it's file URI into the "shareViaEmail" method.

TEST:
Test "shareViaEmail" method over Android 7.0 (Galaxy S7) and Android 8.1.0 (Pixel 2).