### PR TITLE
Rename URLEncodedString to avoid conflicts

### DIFF
--- a/src/ios/NSString+SSURLEncoding.h
+++ b/src/ios/NSString+SSURLEncoding.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 
 @interface NSString (SSURLEncoding)
-@property (readonly) NSString *URLEncodedString;
+@property (readonly) NSString *SSURLEncodedString;
 @end

--- a/src/ios/NSString+SSURLEncoding.m
+++ b/src/ios/NSString+SSURLEncoding.m
@@ -1,7 +1,7 @@
 #import "NSString+SSURLEncoding.h"
 
 @implementation NSString (SSURLEncoding)
-- (NSString*)URLEncodedString
+- (NSString*)SSURLEncodedString
 {
   NSString* result = (NSString *)CFBridgingRelease(
                           CFURLCreateStringByAddingPercentEscapes(

--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -107,7 +107,7 @@ static NSString *const kShareOptionUrl = @"url";
     }
 
     if (urlString != (id)[NSNull null] && urlString != nil) {
-        [activityItems addObject:[NSURL URLWithString:[urlString URLEncodedString]]];
+        [activityItems addObject:[NSURL URLWithString:[urlString SSURLEncodedString]]];
     }
 
     UIActivity *activity = [[UIActivity alloc] init];
@@ -297,7 +297,7 @@ static NSString *const kShareOptionUrl = @"url";
   }
 
   if (urlString != (id)[NSNull null]) {
-    [composeViewController addURL:[NSURL URLWithString:[urlString URLEncodedString]]];
+    [composeViewController addURL:[NSURL URLWithString:[urlString SSURLEncodedString]]];
   }
 
   [composeViewController setCompletionHandler:^(SLComposeViewControllerResult result) {
@@ -646,7 +646,7 @@ static NSString *const kShareOptionUrl = @"url";
       if ([shareString isEqual: @""]) {
         shareString = urlString;
       } else {
-        shareString = [NSString stringWithFormat:@"%@ %@", shareString, [urlString URLEncodedString]];
+        shareString = [NSString stringWithFormat:@"%@ %@", shareString, [urlString SSURLEncodedString]];
       }
     }
     NSString *encodedShareString = [shareString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
The name is very common and sometimes causing conflicts with other
libraries. This happened to me, it might have collided with some SDK.

I spent lots of time debugging why the URL encoding was very aggressive, escaping "://". Later I realized that the customized function wasn't even called. I guess if it's similar to C, the linker can choose any implementation with the same name :(