### PR TITLE
Fix file URL double-encoding

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -778,8 +778,7 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
       NSString *fullPath = [NSString stringWithFormat:@"%@/%@", bundlePath, fileName];
       file = [NSURL fileURLWithPath:fullPath];
     } else if ([fileName hasPrefix:@"file://"]) {
-      // stripping the first 6 chars, because the path should start with / instead of file://
-      file = [NSURL fileURLWithPath:[fileName substringFromIndex:6]];
+      file = [NSURL URLWithString:fileName];
      } else if (rangeData.location != NSNotFound ){
         //If found "data:"
         NSString *fileType  = (NSString*)[[[fileName substringFromIndex:rangeData.location+rangeData.length] componentsSeparatedByString: @";"] objectAtIndex:0];


### PR DESCRIPTION
If the file URL contains percent encoding then the percent encodings are re-encoded, as we treat the already encoded string as a path, so NSURL re-encodes it. We can assume that if the string begins file:// that it is a legal file URL, in which case we can simply use [NSURL URLWithString].