### PR TITLE
Fix navigator.share polyfill breaking Web Share L2

### DIFF
--- a/www/SocialSharing.js
+++ b/www/SocialSharing.js
@@ -137,7 +137,12 @@ SocialSharing.install = function () {
   }
 
   window.plugins.socialsharing = new SocialSharing();
-  navigator.share = window.plugins.socialsharing.shareW3C;
+  
+  // Note only polyfill navigator.share if it is not defined, since shareW3C implements L1 of the spec,
+  // and an existing navigator.share method could implement L2.
+  if (!navigator.share)
+    navigator.share = window.plugins.socialsharing.shareW3C;
+  
   return window.plugins.socialsharing;
 };
 


### PR DESCRIPTION
The Web Share API L2 allows for sharing files, but SocialSharing.js unconditionally overwrites navigator.share with an L1 implementation which does not support sharing files. Only polyfill if navigator.share is not defined, removing the possibility of overwriting an L2 implementation with L1.