### PR TITLE
Fix #1066 - NSNull not handled for iPadCoordString

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -94,8 +94,10 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
     NSString *iPadCoordString = options[kShareOptionIPadCoordinates];
     NSArray *iPadCoordinates;
 
-    if (iPadCoordString != nil) {
+    if (iPadCoordString != nil && iPadCoordString != [NSNull null]) {
       iPadCoordinates = [iPadCoordString componentsSeparatedByString:@","];
+    } else {
+      iPadCoordinates = @[];
     }
 
 


### PR DESCRIPTION
This is a fix for #1066 .  Added an additional check to handle NSNull.