### PR TITLE
Add support for unknown file extensions by assigning them binary MIME type.

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -168,7 +168,7 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
         if (iPadCoords != nil && ![iPadCoords isEqual:@"-1,-1,-1,-1"]) {
           CGRect rect;
           if ([iPadCoordinates count] == 4) {
-           
+
             rect = CGRectMake((int) [[iPadCoordinates objectAtIndex:0] integerValue], (int) [[iPadCoordinates objectAtIndex:1] integerValue], (int) [[iPadCoordinates objectAtIndex:2] integerValue], (int) [[iPadCoordinates objectAtIndex:3] integerValue]);
           } else {
             NSArray *comps = [iPadCoords componentsSeparatedByString:@","];
@@ -470,6 +470,10 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
   NSString *result = (NSString*)CFBridgingRelease(UTTypeCopyPreferredTagWithClass(type, kUTTagClassMIMEType));
   CFRelease(ext);
   CFRelease(type);
+  if (result == nil) {
+    result = @"application/octet-stream";
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Code crashes when trying to attach any files with unknown extensions to emails (like .log files, etc) because iOS does not return a mime type for such files (it returns nil).

This patch assigns binary mime type to any unknown file extensions to fix this.