### PR TITLE
Fix file being deleted on iOS between sharing options

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -134,7 +134,9 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
 
     if ([activityVC respondsToSelector:(@selector(setCompletionWithItemsHandler:))]) {
       [activityVC setCompletionWithItemsHandler:^(NSString *activityType, BOOL completed, NSArray * returnedItems, NSError * activityError) {
-        [self cleanupStoredFiles];
+        if (completed == YES || activityType == nil) {
+            [self cleanupStoredFiles];
+        }
         if (boolResponse) {
           [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:completed]
                                       callbackId:command.callbackId];
@@ -148,7 +150,9 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
       // let's suppress this warning otherwise folks will start opening issues while it's not relevant
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         [activityVC setCompletionHandler:^(NSString *activityType, BOOL completed) {
-          [self cleanupStoredFiles];
+          if (completed == YES || activityType == nil) {
+              [self cleanupStoredFiles];
+          }
           NSDictionary * result = @{@"completed":@(completed), @"app":activityType == nil ? @"" : activityType};
           CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
           [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
This PR is fixing the files being shared from being deleted between 2 sharing options.

Right now, if you choose mail for example then you cancel and choose another sharing option then the files are being removed and no more available to be shared.

Now the files are deleted if:
- the sharing was completed successfully
- or if we exit completely the sharing sheet without sharing