### PR TITLE
Remove commented UIWebView reference

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -33,17 +33,6 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
 - (NSString*)getIPadPopupCoordinates {
   // see https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin/issues/1052
   return nil;
-  /*
-  if (_popupCoordinates != nil) {
-    return _popupCoordinates;
-  }
-  if ([self.webView respondsToSelector:@selector(stringByEvaluatingJavaScriptFromString:)]) {
-    return [(UIWebView*)self.webView stringByEvaluatingJavaScriptFromString:@"window.plugins.socialsharing.iPadPopupCoordinates();"];
-  } else {
-    // prolly a wkwebview, ignoring for now
-    return nil;
-  }
-  */
 }
 
 - (void)setIPadPopupCoordinates:(CDVInvokedUrlCommand*)command {


### PR DESCRIPTION
It just removes a commented line so Apple doesn't reject builds for finding "UIWebView" 

Solves #1106  

