### PR TITLE
Fix for https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plug…

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -680,7 +680,10 @@ public class SocialSharing extends CordovaPlugin {
     for (final ResolveInfo app : activityList) {
       if ((app.activityInfo.packageName).contains(appPackageName)) {
         if (appName == null || (app.activityInfo.name).contains(appName)) {
-          return app.activityInfo;
+          if (appPackageName == "instagram"
+              && app.activityInfo.name.contains("ShareHandlerActivity")) {
+            return app.activityInfo;
+          }
         }
       }
     }


### PR DESCRIPTION
Fix for #1033 

This stops the direct activity sharing been selected on the android platform where instagram registers multiple activities as shown below:

- com.instagram.direct.share.handler.DirectExternalPhotoShareActivity
- com.instagram.share.handleractivity.ShareHandlerActivity
- com.instagram.share.handleractivity.StoryShareHandlerActivity

The story share handler is implied by passing multiple images through to the plugin.