### PR TITLE
Fixes for #1033 where instagram always goes to direct messages

### DIFF
--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -680,7 +680,10 @@ public class SocialSharing extends CordovaPlugin {
     for (final ResolveInfo app : activityList) {
       if ((app.activityInfo.packageName).contains(appPackageName)) {
         if (appName == null || (app.activityInfo.name).contains(appName)) {
-          return app.activityInfo;
+          if (appPackageName == "instagram"
+              && app.activityInfo.name.contains("ShareHandlerActivity")) {
+            return app.activityInfo;
+          }
         }
       }
     }

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -103,7 +103,7 @@ public class SocialSharing extends CordovaPlugin {
       if (notEmpty(args.getString(0))) {
         copyHintToClipboard(args.getString(0), "Instagram paste message");
       }
-      return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "instagram", null, false, true);
+      return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), "com.instagram.android", null, false, true, "com.instagram.share.handleractivity.ShareHandlerActivity");
     } else if (ACTION_CAN_SHARE_VIA.equals(action)) {
       return doSendIntent(callbackContext, args.getString(0), args.getString(1), args.getJSONArray(2), args.getString(3), args.getString(4), null, true, true);
     } else if (ACTION_CAN_SHARE_VIA_EMAIL.equals(action)) {
@@ -680,10 +680,7 @@ public class SocialSharing extends CordovaPlugin {
     for (final ResolveInfo app : activityList) {
       if ((app.activityInfo.packageName).contains(appPackageName)) {
         if (appName == null || (app.activityInfo.name).contains(appName)) {
-          if (appPackageName == "instagram"
-              && app.activityInfo.name.contains("ShareHandlerActivity")) {
-            return app.activityInfo;
-          }
+          return app.activityInfo;
         }
       }
     }


### PR DESCRIPTION
This stops the direct activity sharing been selected on the android platform where instagram registers multiple activities as shown below:

- com.instagram.direct.share.handler.DirectExternalPhotoShareActivity
- com.instagram.share.handleractivity.ShareHandlerActivity
- com.instagram.share.handleractivity.StoryShareHandlerActivity
- com.instagram.share.handleractivity.MultiStoryShareHandlerActivity
The story share handler is implied by passing multiple images through to the plugin.