### PR TITLE
Fix for "file://"-prefixed URLs

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -779,7 +779,7 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
       file = [NSURL fileURLWithPath:fullPath];
     } else if ([fileName hasPrefix:@"file://"]) {
       // stripping the first 6 chars, because the path should start with / instead of file://
-      file = [NSURL fileURLWithPath:[fileName substringFromIndex:6]];
+      file = [NSURL fileURLWithPath:[fileName substringFromIndex:7]];
      } else if (rangeData.location != NSNotFound ){
         //If found "data:"
         NSString *fileType  = (NSString*)[[[fileName substringFromIndex:rangeData.location+rangeData.length] componentsSeparatedByString: @";"] objectAtIndex:0];


### PR DESCRIPTION
The current implementation strips only "file:/" from the given string which results in NSURLs looking like "file:////var/..." where the original strings looked like "file:///var/..." 