### PR TITLE
Fixes shareViaSMS bug, opts.image present removes message body

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -510,9 +510,10 @@ static NSString *const kShareOptionIPadCoordinates = @"iPadCoordinates";
     if (image != nil && image != (id)[NSNull null]) {
       BOOL canSendAttachments = [[MFMessageComposeViewController class] respondsToSelector:@selector(canSendAttachments)];
       if (canSendAttachments) {
-        NSURL *file = [self getFile:image];
-        if (file != nil) {
-          [picker addAttachmentURL:file withAlternateFilename:nil];
+        UIImage *uiImg = [self getImage:image];
+        if (uiImg != nil) {
+          NSData *dataImg = UIImagePNGRepresentation(uiImg);
+          [picker addAttachmentData:dataImg typeIdentifier:@"public.data" filename:@"Image.png"];
         }
       }
     }


### PR DESCRIPTION
Issue...

If options.image passed, options.message was not present in iOS message controller.

- replaces getFile call with getImage call
- translates image to png and then attaches as addAttachmentData instead of addAttachmentURL

Modified:

- src/ios/SocialSharing.m

You can recreate the issue with the following code. "test" will not be added to the body of the SMS but the image will be present.

```
function testSharing(){
    var options = {
      message : 'test',
      image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
    }
  
    plugins.socialsharing.shareViaSMS(options)
}
```