### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,7 @@
 
 
     <config-file target="AndroidManifest.xml" parent="/*/application">
-      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true">
+      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true" android:exported="false">
         <intent-filter>
           <action android:name="android.intent.action.SEND"/>
         </intent-filter>


### PR DESCRIPTION
To solve this error;
Build failed with the following error: There was an issue generating the app. Elements of type "receiver" with defined intent filters must declare a value for "android:exported" in all AndroidManifest.xml files, both in the app and Gradle dependencies. Check your plugin configurations and try again.