### PR TITLE
Support for Android SDK 31

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,7 @@
 
 
     <config-file target="AndroidManifest.xml" parent="/*/application">
-      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true">
+      <receiver android:exported="false" android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true">
         <intent-filter>
           <action android:name="android.intent.action.SEND"/>
         </intent-filter>


### PR DESCRIPTION
Support for Android SDK 31, 

Error:: Manifest merger failed : Apps targeting Android 12 and higher are required to specify an explicit value for android:exported when the corresponding component has an intent filter defined. See https://developer.android. com/guide/topics/manifest/activity-element#exported for details.