### PR TITLE
Set the plugin android:exported property

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,7 @@
 
 
     <config-file target="AndroidManifest.xml" parent="/*/application">
-      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true">
+      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true" android:exported="true">
         <intent-filter>
           <action android:name="android.intent.action.SEND"/>
         </intent-filter>


### PR DESCRIPTION
- Since Android 12+ it is required to explicitly set the
android:exported property when the corresponding component
 has an intent filter defined.