### PR TITLE
Remove deprecated dependency es6-promise

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,6 @@
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
 
-  <dependency id="es6-promise-plugin" version="^4.1.0" />
-
   <js-module src="www/SocialSharing.js" name="SocialSharing">
     <clobbers target="window.plugins.socialsharing" />
   </js-module>


### PR DESCRIPTION
This removed an old dependency that is no longer maintained and probably not needed anymore of es6-promise.
All modern browsers support promises now, this doesn't seem like a wanted dependency anymore.
More over, old stuff accumulate security issues and deprecated plugins do not update their dependencies to fix these security issues...