### PR TITLE
Fix ActivityNotFoundException on Android 13

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -89,6 +89,12 @@
       </provider>
     </config-file>
 
+    <config-file target="AndroidManifest.xml" parent="/*">
+      <queries>
+        <package android:name="com.whatsapp" />
+      </queries>
+    </config-file>
+
     <source-file src="src/android/nl/xservices/plugins/SocialSharing.java" target-dir="src/nl/xservices/plugins"/>
     <source-file src="src/android/nl/xservices/plugins/ShareChooserPendingIntent.java" target-dir="src/nl/xservices/plugins"/>
     <source-file src="src/android/nl/xservices/plugins/FileProvider.java" target-dir="src/nl/xservices/plugins"/>

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -338,7 +338,12 @@ public class SocialSharing extends CordovaPlugin {
             if (peek) {
               callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
             } else {
-              sendIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+              // Android 13 blocks intents that don't match with the receiving app intent-filters
+              // In order to prevent ActivityNotFoundException the category is added to the intent only on Android 12L and below
+              if (Build.VERSION.SDK_INT < 33) {
+                sendIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+              }
+
               sendIntent.setComponent(new ComponentName(activity.applicationInfo.packageName,
                   passedActivityName != null ? passedActivityName : activity.name));
 


### PR DESCRIPTION
Fixes ActivityNotFoundException when sharing to WhatsApp, Facebook, Twitter on Android 13 caused by the new "Intent filters block non-matching intents" change.

This fixes #1200 and also the same issue I've reproed when sharing to WhatsApp.

The second commit is a fix a repro where the WhatsApp application wasn't recognised as being installed on the device.