### PR TITLE
Update plugin.xml - remove es6 promise plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,9 +24,7 @@
   <engines>
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
-
-  <dependency id="es6-promise-plugin" version="^4.1.0" />
-
+        
   <js-module src="www/SocialSharing.js" name="SocialSharing">
     <clobbers target="window.plugins.socialsharing" />
   </js-module>


### PR DESCRIPTION
The ES6 promise plugin addon has become irrelevant since Android 5.0. And since Play Store submissions don't allow targeting [API < 21](https://apilevels.com/) anymore, this plugin should no longer be included in any modern cordova project.