### PR TITLE
fix(android): harden receiver for CVE-2025-65835

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,11 +72,7 @@
 
 
     <config-file target="AndroidManifest.xml" parent="/*/application">
-      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true" android:exported="true">
-        <intent-filter>
-          <action android:name="android.intent.action.SEND"/>
-        </intent-filter>
-      </receiver>
+      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true" android:exported="false"/>
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/*">

--- a/src/android/nl/xservices/plugins/ShareChooserPendingIntent.java
+++ b/src/android/nl/xservices/plugins/ShareChooserPendingIntent.java
@@ -1,16 +1,28 @@
 package nl.xservices.plugins;
 
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
+import android.os.Bundle;
 
 public class ShareChooserPendingIntent extends BroadcastReceiver {
     public static String chosenComponent = null;
+
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent.getExtras() != null) {
-            ShareChooserPendingIntent.chosenComponent = intent.getExtras().get(Intent.EXTRA_CHOSEN_COMPONENT).toString();
+        if (intent == null) {
+            return;
+        }
+
+        Bundle extras = intent.getExtras();
+        if (extras == null || !extras.containsKey(Intent.EXTRA_CHOSEN_COMPONENT)) {
+            return;
+        }
+
+        Object chosen = extras.get(Intent.EXTRA_CHOSEN_COMPONENT);
+        if (chosen instanceof ComponentName) {
+            ShareChooserPendingIntent.chosenComponent = ((ComponentName) chosen).flattenToString();
         }
     }
 }

--- a/src/android/nl/xservices/plugins/ShareChooserPendingIntent.java
+++ b/src/android/nl/xservices/plugins/ShareChooserPendingIntent.java
@@ -11,6 +11,8 @@ public class ShareChooserPendingIntent extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        ShareChooserPendingIntent.chosenComponent = null;
+
         if (intent == null) {
             return;
         }

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -373,6 +373,7 @@ public class SocialSharing extends CordovaPlugin {
             cordova.getActivity().runOnUiThread(new Runnable() {
               public void run() {
                 Intent chooseIntent;
+                ShareChooserPendingIntent.chosenComponent = null;
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP_MR1) {
                   // Intent.createChooser's third param was only added in SDK version 22.
                   chooseIntent = Intent.createChooser(sendIntent, chooserTitle, pendingIntent.getIntentSender());
@@ -710,8 +711,10 @@ public class SocialSharing extends CordovaPlugin {
         case ACTIVITY_CODE_SEND__OBJECT:
           JSONObject json = new JSONObject();
           try {
+            final String chosenComponent = ShareChooserPendingIntent.chosenComponent;
+            ShareChooserPendingIntent.chosenComponent = null;
             json.put("completed", resultCode == Activity.RESULT_OK);
-            json.put("app", (ShareChooserPendingIntent.chosenComponent != null ? ShareChooserPendingIntent.chosenComponent : "")); // we need a completely different approach if we want to support this on Android. Idea: https://clickclickclack.wordpress.com/2012/01/03/intercepting-androids-action_send-intents/
+            json.put("app", (chosenComponent != null ? chosenComponent : "")); // we need a completely different approach if we want to support this on Android. Idea: https://clickclickclack.wordpress.com/2012/01/03/intercepting-androids-action_send-intents/
             _callbackContext.sendPluginResult(new PluginResult(
                 PluginResult.Status.OK,
                 json));


### PR DESCRIPTION
## Motivation

Fix the risk related to CVE-2025-65835 by preventing external/malicious Intents from triggering the plugin’s BroadcastReceiver, which could lead to receiver abuse, NullPointerException, or type-cast errors.